### PR TITLE
make user relative with $USER instead of ubuntu

### DIFF
--- a/install-regen-logrotate.sh
+++ b/install-regen-logrotate.sh
@@ -1,14 +1,36 @@
 #!/bin/bash
 
-LOG_PATH="/home/ubuntu/logs/regen"
+LOG_PATH="/home/$USER/logs/regen"
 LOG_FILE=$LOG_PATH/regen-utils.log
+
+mkdir -p $LOG_PATH
 
 exec &> >(tee -a "$LOG_FILE")
 
 echo [$(date -u)]
 echo ... Installing Regen Log Rotation and Crontab
-sudo cp /home/ubuntu/code/regen-utils/regen.logrotate /etc/logrotate.d/regen
-sudo bash -c "echo '* * * * * * ubuntu sudo logrotate -f /etc/logrotate.d/regen' > /etc/cron.d/regen"
 
-echo Log rotation will run every minute
+echo "/home/$USER/logs/regen/*.log {
+    su $USER $USER
+    hourly
+    create 0644 $USER $USER
+    rotate 5
+    dateext
+    dateformat -%Y%m%d%H-%s
+    size=1M
+    notifempty
+    copytruncate
+    postrotate
+	echo [$(date -u)] >> /home/$USER/logs/regen/regen-utils.log
+	echo "Regen log $1 rotated" >> /home/$USER/logs/regen/regen-utils.log
+    endscript
+}
+" >regen.logrotate
+
+
+sudo mv regen.logrotate /etc/logrotate.d/regen
+sudo bash -c "echo '* * * * * * $USER sudo logrotate -f /etc/logrotate.d/regen' > /etc/cron.d/regen"
+
+echo Log rotation will run every minute.
+echo Logs are in /home/$USER/logs/regen.
 echo Done.


### PR DESCRIPTION
These changes also make the separate regen.logrotate file obsolete, because those contents are generated in this script in order to make the user relative and not depend on having a ~/code directory. Changed cp to mv in order to not leave a regen.logrotate file lying around wherever the script is run.